### PR TITLE
Set app name to NetBeans

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -2,3 +2,5 @@ auxiliary.org-netbeans-spi-editor-hints-projects.perProjectHintSettingsFile=nbpr
 javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file=license.txt
+app.name=NetBeans
+


### PR DESCRIPTION
Fixes issue of it showing ${app.name} on Mac

Signed-off-by: David Woods d.woods92@gmail.com
