### PR TITLE
Updated module name and category

### DIFF
--- a/src/com/codeigniter/netbeans/Bundle.properties
+++ b/src/com/codeigniter/netbeans/Bundle.properties
@@ -1,1 +1,5 @@
-OpenIDE-Module-Name=netbeans-plugin
+OpenIDE-Module-Display-Category=PHP
+OpenIDE-Module-Long-Description=\
+    Support for CodeIgniter3
+OpenIDE-Module-Name=CodeIgniter3 framework
+OpenIDE-Module-Short-Description=Plugin for CodeIgniter


### PR DESCRIPTION
Changed name to "CodeIgniter3 framework" and category to "PHP" as per issue #29 description
closes #29 

Signed-off-by: David Woods d.woods92@gmail.com
